### PR TITLE
Adding support for schema agreement options

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,10 @@ cassandra:
     - continuous-cql-requests
   nodeMetrics:
     - bytes-sent
+  schema:
+    agreementIntervalMilliseconds: 200
+    agreementTimeoutSeconds: 10
+    agreementWarnOnFailure: true
 ```
 
 #### Note on Multi-Environment Configuration

--- a/src/main/java/io/dropwizard/cassandra/CassandraFactory.java
+++ b/src/main/java/io/dropwizard/cassandra/CassandraFactory.java
@@ -23,6 +23,7 @@ import io.dropwizard.cassandra.reconnection.ExponentialReconnectionPolicyFactory
 import io.dropwizard.cassandra.reconnection.ReconnectionPolicyFactory;
 import io.dropwizard.cassandra.request.RequestOptionsFactory;
 import io.dropwizard.cassandra.retry.RetryPolicyFactory;
+import io.dropwizard.cassandra.schema.SchemaOptionsFactory;
 import io.dropwizard.cassandra.speculativeexecution.SpeculativeExecutionPolicyFactory;
 import io.dropwizard.cassandra.ssl.SSLOptionsFactory;
 import io.dropwizard.cassandra.timestamp.AtomicMonotonicTimestampGeneratorFactory;
@@ -73,6 +74,9 @@ public abstract class CassandraFactory implements Discoverable {
     @Valid
     @JsonProperty
     protected PoolingOptionsFactory poolingOptions;
+    @Valid
+    @JsonProperty
+    protected SchemaOptionsFactory schemaOptions;
     @Valid
     @JsonProperty
     protected AddressTranslatorFactory addressTranslator;
@@ -152,7 +156,7 @@ public abstract class CassandraFactory implements Discoverable {
     public boolean isMetricsEnabled() {
         return metricsEnabled;
     }
-  
+
     public void setMetricsEnabled(final boolean metricsEnabled) {
         this.metricsEnabled = metricsEnabled;
     }
@@ -219,6 +223,14 @@ public abstract class CassandraFactory implements Discoverable {
 
     public void setPoolingOptions(final PoolingOptionsFactory poolingOptions) {
         this.poolingOptions = poolingOptions;
+    }
+
+    public SchemaOptionsFactory getSchemaOptions() {
+        return schemaOptions;
+    }
+
+    public void setSchemaOptions(final SchemaOptionsFactory schemaOptions) {
+        this.schemaOptions = schemaOptions;
     }
 
     public AddressTranslatorFactory getAddressTranslator() {
@@ -291,6 +303,7 @@ public abstract class CassandraFactory implements Discoverable {
                 .configBuilderHelper(retryPolicy, configLoaderBuilder)
                 .configBuilderHelper(speculativeExecutionPolicy, configLoaderBuilder)
                 .configBuilderHelper(poolingOptions, configLoaderBuilder)
+                .configBuilderHelper(schemaOptions, configLoaderBuilder)
                 .configBuilderHelper(addressTranslator, configLoaderBuilder)
                 .configBuilderHelper(requestOptionsFactory, configLoaderBuilder)
                 .configBuilderHelper(loadBalancingPolicy, configLoaderBuilder)

--- a/src/main/java/io/dropwizard/cassandra/schema/SchemaOptionsFactory.java
+++ b/src/main/java/io/dropwizard/cassandra/schema/SchemaOptionsFactory.java
@@ -1,0 +1,57 @@
+package io.dropwizard.cassandra.schema;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.dropwizard.cassandra.DropwizardCassandraConfigBuilder;
+import io.dropwizard.cassandra.DropwizardProgrammaticDriverConfigLoaderBuilder;
+
+import static com.datastax.oss.driver.api.core.config.DefaultDriverOption.CONTROL_CONNECTION_AGREEMENT_INTERVAL;
+import static com.datastax.oss.driver.api.core.config.DefaultDriverOption.CONTROL_CONNECTION_AGREEMENT_TIMEOUT;
+import static com.datastax.oss.driver.api.core.config.DefaultDriverOption.CONTROL_CONNECTION_AGREEMENT_WARN;
+
+public class SchemaOptionsFactory implements DropwizardCassandraConfigBuilder {
+    // Default as defined at https://github.com/datastax/java-driver/blob/f08db2ef5fcc70b3486bd0b9ad74e9356a1be7bc/core/src/main/java/com/datastax/oss/driver/api/core/config/OptionsMap.java#L358
+    public static final Integer DEFAULT_SCHEMA_AGREEMENT_INTERVAL_MILLISECONDS = 200;
+    // Default as defined at https://github.com/datastax/java-driver/blob/f08db2ef5fcc70b3486bd0b9ad74e9356a1be7bc/core/src/main/java/com/datastax/oss/driver/api/core/config/OptionsMap.java#L359
+    public static final Integer DEFAULT_SCHEMA_AGREEMENT_TIMEOUT_SECONDS = 10;
+    // Default as defined at https://github.com/datastax/java-driver/blob/f08db2ef5fcc70b3486bd0b9ad74e9356a1be7bc/core/src/main/java/com/datastax/oss/driver/api/core/config/OptionsMap.java#L360
+    public static final Boolean DEFAULT_SCHEMA_AGREEMENT_WARN_ON_FAILURE = Boolean.TRUE;
+
+    @JsonProperty
+    private Integer agreementTimeoutSeconds = DEFAULT_SCHEMA_AGREEMENT_TIMEOUT_SECONDS;
+    @JsonProperty
+    private Integer agreementIntervalMilliseconds = DEFAULT_SCHEMA_AGREEMENT_INTERVAL_MILLISECONDS;
+    @JsonProperty
+    private Boolean agreementWarnOnFailure = DEFAULT_SCHEMA_AGREEMENT_WARN_ON_FAILURE;
+
+    public Integer getAgreementIntervalMilliseconds() {
+        return agreementIntervalMilliseconds;
+    }
+
+    public void setAgreementIntervalMilliseconds(Integer agreementIntervalMilliseconds) {
+        this.agreementIntervalMilliseconds = agreementIntervalMilliseconds;
+    }
+
+    public Integer getAgreementTimeoutSeconds() {
+        return agreementTimeoutSeconds;
+    }
+
+    public void setAgreementTimeoutSeconds(Integer agreementTimeoutSeconds) {
+        this.agreementTimeoutSeconds = agreementTimeoutSeconds;
+    }
+
+    public Boolean getAgreementWarnOnFailure() {
+        return agreementWarnOnFailure;
+    }
+
+    public void setAgreementWarnOnFailure(Boolean agreementWarnOnFailure) {
+        this.agreementWarnOnFailure = agreementWarnOnFailure;
+    }
+
+    @Override
+    public void accept(DropwizardProgrammaticDriverConfigLoaderBuilder builder) {
+        builder
+            .withNullSafeInteger(CONTROL_CONNECTION_AGREEMENT_INTERVAL, getAgreementIntervalMilliseconds())
+            .withNullSafeInteger(CONTROL_CONNECTION_AGREEMENT_TIMEOUT, getAgreementTimeoutSeconds())
+            .withNullSafeBoolean(CONTROL_CONNECTION_AGREEMENT_WARN, getAgreementWarnOnFailure());
+    }
+}

--- a/src/test/java/io/dropwizard/cassandra/schema/SchemaOptionsFactoryTest.java
+++ b/src/test/java/io/dropwizard/cassandra/schema/SchemaOptionsFactoryTest.java
@@ -1,0 +1,82 @@
+package io.dropwizard.cassandra.schema;
+
+import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
+import com.datastax.oss.driver.api.core.config.DriverExecutionProfile;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.io.Resources;
+import io.dropwizard.cassandra.DropwizardProgrammaticDriverConfigLoaderBuilder;
+import io.dropwizard.configuration.ConfigurationException;
+import io.dropwizard.configuration.YamlConfigurationFactory;
+import io.dropwizard.jackson.Jackson;
+import io.dropwizard.jersey.validation.Validators;
+import org.junit.Test;
+
+import javax.validation.Validator;
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+
+import static io.dropwizard.cassandra.schema.SchemaOptionsFactory.DEFAULT_SCHEMA_AGREEMENT_INTERVAL_MILLISECONDS;
+import static io.dropwizard.cassandra.schema.SchemaOptionsFactory.DEFAULT_SCHEMA_AGREEMENT_TIMEOUT_SECONDS;
+import static io.dropwizard.cassandra.schema.SchemaOptionsFactory.DEFAULT_SCHEMA_AGREEMENT_WARN_ON_FAILURE;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SchemaOptionsFactoryTest {
+    private final ObjectMapper objectMapper = Jackson.newObjectMapper();
+    private final Validator validator = Validators.newValidator();
+    private final YamlConfigurationFactory<SchemaOptionsFactory> factory =
+            new YamlConfigurationFactory<>(SchemaOptionsFactory.class, validator, objectMapper, "dw");
+
+    @Test
+    public void shouldBuildDefaultSchemaOptions() throws URISyntaxException, IOException, ConfigurationException {
+        // Load a default copy of the options factory
+        final SchemaOptionsFactory factory = this.factory.build();
+
+        // Validate that the factory contains values as expected
+        assertThat(factory.getAgreementIntervalMilliseconds())
+                .isEqualTo(DEFAULT_SCHEMA_AGREEMENT_INTERVAL_MILLISECONDS);
+        assertThat(factory.getAgreementTimeoutSeconds())
+                .isEqualTo(DEFAULT_SCHEMA_AGREEMENT_TIMEOUT_SECONDS);
+        assertThat(factory.getAgreementWarnOnFailure())
+                .isEqualTo(DEFAULT_SCHEMA_AGREEMENT_WARN_ON_FAILURE);
+
+        // Validate that the driver configuration contains the values as expected
+        DropwizardProgrammaticDriverConfigLoaderBuilder builder = DropwizardProgrammaticDriverConfigLoaderBuilder.newInstance();
+        factory.accept(builder);
+        DriverExecutionProfile profile = builder.build().getInitialConfig().getDefaultProfile();
+
+        assertThat(profile.getInt(DefaultDriverOption.CONTROL_CONNECTION_AGREEMENT_INTERVAL))
+                .isEqualTo(DEFAULT_SCHEMA_AGREEMENT_INTERVAL_MILLISECONDS);
+        assertThat(profile.getInt(DefaultDriverOption.CONTROL_CONNECTION_AGREEMENT_TIMEOUT))
+                .isEqualTo(DEFAULT_SCHEMA_AGREEMENT_TIMEOUT_SECONDS);
+        assertThat(profile.getBoolean(DefaultDriverOption.CONTROL_CONNECTION_AGREEMENT_WARN))
+                .isEqualTo(DEFAULT_SCHEMA_AGREEMENT_WARN_ON_FAILURE);
+    }
+
+    @Test
+    public void shouldBuildSchemaOptions() throws URISyntaxException, IOException, ConfigurationException {
+        // Load a customized copy of the optiosn factory as defined in the yaml file
+        final File yaml = new File(Resources.getResource("smoke/schema/schema-options.yaml").toURI());
+        final SchemaOptionsFactory factory = this.factory.build(yaml);
+
+        // Validate that the factory contains values as expected
+        assertThat(factory.getAgreementIntervalMilliseconds())
+                .isEqualTo(400);
+        assertThat(factory.getAgreementTimeoutSeconds())
+                .isEqualTo(20);
+        assertThat(factory.getAgreementWarnOnFailure())
+                .isEqualTo(false);
+
+        DropwizardProgrammaticDriverConfigLoaderBuilder builder = DropwizardProgrammaticDriverConfigLoaderBuilder.newInstance();
+        factory.accept(builder);
+        DriverExecutionProfile profile = builder.build().getInitialConfig().getDefaultProfile();
+
+        // Validate that the driver configuration contains the values as expected
+        assertThat(profile.getInt(DefaultDriverOption.CONTROL_CONNECTION_AGREEMENT_INTERVAL))
+                .isEqualTo(400);
+        assertThat(profile.getInt(DefaultDriverOption.CONTROL_CONNECTION_AGREEMENT_TIMEOUT))
+                .isEqualTo(20);
+        assertThat(profile.getBoolean(DefaultDriverOption.CONTROL_CONNECTION_AGREEMENT_WARN))
+                .isEqualTo(false);
+    }
+}

--- a/src/test/resources/smoke/schema/schema-options.yaml
+++ b/src/test/resources/smoke/schema/schema-options.yaml
@@ -1,0 +1,3 @@
+agreementIntervalMilliseconds: 400
+agreementTimeoutSeconds: 20
+agreementWarnOnFailure: false


### PR DESCRIPTION
* Three new options under a new schema category:
```
  schema:
    agreementIntervalMilliseconds: 200
    agreementTimeoutSeconds: 10
    agreementWarnOnFailure: true
```
* Adds two new tests related to the rendering of these new options: default values, custom values
* Updates README to reflect the new options (and their default values)

Fixes #83 